### PR TITLE
Turn on mosfet when switching from OFF to ON.

### DIFF
--- a/MPPT_Code/MPPT_Code.ino
+++ b/MPPT_Code/MPPT_Code.ino
@@ -368,9 +368,11 @@ void run_charger(void) {
         off_count--;                                        // anything, this is to allow the battery voltage to settle down to see if the  
       }                                                     // battery has been disconnected
       else if ((bat_volts > BATT_FLOAT) && (sol_volts > bat_volts)) {
+        TURN_ON_MOSFETS;
         charger_state = bat_float;                          // if battery voltage is still high and solar volts are high
       }    
       else if ((bat_volts > MIN_BAT_VOLTS) && (bat_volts < BATT_FLOAT) && (sol_volts > bat_volts)) {
+        TURN_ON_MOSFETS;
         charger_state = bulk;
       }
       break;


### PR DESCRIPTION
This is required after the sun goes down and back up, or during startup. The mosfets must be turned back on after switching back to a charging state
